### PR TITLE
add main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "vinyl-paths": "^1.0.0",
     "yargs": "^2.1.1"
   },
+  "main": "dist/commonjs/index.js",
   "jspm": {
     "registry": "npm",
     "main": "index",


### PR DESCRIPTION
To use this package with Aurelia webpack skeleton it has to define `main` property in `package.json`. Details here http://stackoverflow.com/questions/39161049/how-to-override-plugins-main-property-in-aurelia-webpack-skeleton.
